### PR TITLE
Add allowed third party domains option (#1)

### DIFF
--- a/index.js
+++ b/index.js
@@ -53,6 +53,7 @@ const defaultOptions = {
   removeBlobs: true,
   fixInsertRule: true,
   skipThirdPartyRequests: false,
+  includedThirdPartyRequests: [],
   cacheAjaxRequests: false,
   http2PushManifest: false,
   // may use some glob solution in the future, if required

--- a/src/puppeteer_utils.js
+++ b/src/puppeteer_utils.js
@@ -13,20 +13,37 @@ const errorToString = (jsHandle) =>
 const objectToJson = (jsHandle) => jsHandle.jsonValue();
 
 /**
- * @param {{page: Page, options: {skipThirdPartyRequests: true}, basePath: string }} opt
+ * @param {request: {url: function, abort: function, continue: function}, basePath: string, includedThirdPartyRequests: []}
+ * @return {undefined}
+ */
+const thirdPartyRequestHandler = (
+  request,
+  basePath,
+  includedThirdPartyRequests
+) => {
+  const url = request.url();
+  if (
+    url.startsWith(basePath) ||
+    includedThirdPartyRequests.some(d => url.startsWith(d))
+  ) {
+    request.continue();
+  } else {
+    request.abort();
+  }
+};
+
+/**
+ * @param {{page: Page, options: {skipThirdPartyRequests: true, includedThirdPartyRequests: []}, basePath: string }} opt
  * @return {Promise<void>}
  */
 const skipThirdPartyRequests = async (opt) => {
   const { page, options, basePath } = opt;
-  if (!options.skipThirdPartyRequests) return;
+  const { skipThirdPartyRequests, includedThirdPartyRequests } = options;
+  if (!skipThirdPartyRequests) return;
   await page.setRequestInterception(true);
-  page.on("request", (request) => {
-    if (request.url().startsWith(basePath)) {
-      request.continue();
-    } else {
-      request.abort();
-    }
-  });
+  page.on("request", request =>
+    thirdPartyRequestHandler(request, basePath, includedThirdPartyRequests)
+  );
 };
 
 /**
@@ -304,6 +321,7 @@ const crawl = async (opt) => {
 };
 
 exports.skipThirdPartyRequests = skipThirdPartyRequests;
+exports.thirdPartyRequestHandler = thirdPartyRequestHandler;
 exports.enableLogging = enableLogging;
 exports.getLinks = getLinks;
 exports.crawl = crawl;

--- a/tests/__snapshots__/defaultOptions.test.js.snap
+++ b/tests/__snapshots__/defaultOptions.test.js.snap
@@ -18,6 +18,7 @@ Object {
   "include": Array [
     "/",
   ],
+  "includedThirdPartyRequests": Array [],
   "inlineCss": false,
   "minifyCss": Object {},
   "minifyHtml": Object {


### PR DESCRIPTION
* Add support for allowed third party domains

* Ran changes through prettier

* Extracted puppeteer request handler for 3rd party urls. Added tests.

Co-authored-by: Harry Green <harryharryharry@gmail.com>